### PR TITLE
Fix typing syntax for Python 3.8 compatibility

### DIFF
--- a/GeneradorMontunos/autocomplete.py
+++ b/GeneradorMontunos/autocomplete.py
@@ -3,7 +3,7 @@
 
 import customtkinter as ctk
 from tkinter import Listbox, END, ACTIVE
-from typing import List
+from typing import List, Optional
 import re
 
 from voicings import INTERVALOS_TRADICIONALES, NOTAS, parsear_nombre_acorde
@@ -14,10 +14,10 @@ class ChordAutocomplete(ctk.CTkTextbox):
 
     def __init__(self, master=None, **kwargs):
         super().__init__(master, **kwargs)
-        self._popup: ctk.CTkToplevel | None = None
-        self._listbox: Listbox | None = None
+        self._popup: Optional[ctk.CTkToplevel] = None
+        self._listbox: Optional[Listbox] = None
         self._suggestions: List[str] = []
-        self._popup_type: str | None = None
+        self._popup_type: Optional[str] = None
 
         self._roots = sorted(NOTAS.keys(), key=lambda x: (len(x), x))
 

--- a/GeneradorMontunos/midi_utils.py
+++ b/GeneradorMontunos/midi_utils.py
@@ -2,7 +2,7 @@
 """Helpers for reading, manipulating and exporting MIDI files."""
 
 from pathlib import Path
-from typing import List, Tuple
+from typing import Dict, List, Optional, Tuple
 import math
 import pretty_midi
 import random
@@ -44,7 +44,7 @@ def aplicar_voicings_a_referencia(
     """
 
     # Mapeo corchea → índice de voicing
-    mapa: dict[int, int] = {}
+    mapa: Dict[int, int] = {}
     max_idx = -1
     for i, (_, idxs) in enumerate(asignaciones):
         for ix in idxs:
@@ -139,13 +139,13 @@ def _arm_por_parejas(
     """
 
     # Map each eighth index to the corresponding voicing/chord
-    mapa: dict[int, int] = {}
+    mapa: Dict[int, int] = {}
     for i, (_, idxs) in enumerate(asignaciones):
         for ix in idxs:
             mapa[ix] = i
 
     # Counter so each chord advances through its voicing in parallel
-    contadores: dict[int, int] = {}
+    contadores: Dict[int, int] = {}
 
     resultado: List[pretty_midi.Note] = []
     for pos in posiciones:
@@ -221,12 +221,12 @@ def _arm_decimas_intervalos(
     # and flags indicating whether it is a sixth chord or a diminished
     # seventh.
     # ------------------------------------------------------------------
-    mapa: dict[int, int] = {}
+    mapa: Dict[int, int] = {}
     for i, (_, idxs) in enumerate(asignaciones):
         for ix in idxs:
             mapa[ix] = i
 
-    info: list[dict] = []
+    info: List[Dict] = []
     for nombre, _ in asignaciones:
         root_pc, suf = parsear_nombre_acorde(nombre)
         ints = INTERVALOS_TRADICIONALES[suf]
@@ -242,10 +242,10 @@ def _arm_decimas_intervalos(
             }
         )
 
-    contadores: dict[int, int] = {}
-    offsets: dict[int, int] = {}
-    bajo_anterior: int | None = None
-    arm_anterior: str | None = None
+    contadores: Dict[int, int] = {}
+    offsets: Dict[int, int] = {}
+    bajo_anterior: Optional[int] = None
+    arm_anterior: Optional[str] = None
     resultado: List[pretty_midi.Note] = []
 
     for pos in posiciones:
@@ -355,12 +355,12 @@ def _arm_treceavas_intervalos(
     the added voice is placed a thirteenth (20 or 21 semitones) below it.
     """
 
-    mapa: dict[int, int] = {}
+    mapa: Dict[int, int] = {}
     for i, (_, idxs) in enumerate(asignaciones):
         for ix in idxs:
             mapa[ix] = i
 
-    info: list[dict] = []
+    info: List[Dict] = []
     for nombre, _ in asignaciones:
         root_pc, suf = parsear_nombre_acorde(nombre)
         ints = INTERVALOS_TRADICIONALES[suf]
@@ -376,7 +376,7 @@ def _arm_treceavas_intervalos(
             }
         )
 
-    contadores: dict[int, int] = {}
+    contadores: Dict[int, int] = {}
     resultado: List[pretty_midi.Note] = []
 
     for pos in posiciones:
@@ -474,7 +474,7 @@ _ARMONIZADORES = {
 }
 
 
-def _ajustar_salto(prev_pitch: int | None, pitch: int) -> int:
+def _ajustar_salto(prev_pitch: Optional[int], pitch: int) -> int:
     """Return ``pitch`` transposed by octaves so the leap from ``prev_pitch``
     is less than an octave."""
 
@@ -500,14 +500,14 @@ def generar_notas_mixtas(
     ``asignaciones`` debe contener tuplas ``(acorde, indices, armonizacion)``.
     """
 
-    mapa: dict[int, int] = {}
-    armonias: dict[int, str] = {}
+    mapa: Dict[int, int] = {}
+    armonias: Dict[int, str] = {}
     for i, (_, idxs, arm) in enumerate(asignaciones):
         for ix in idxs:
             mapa[ix] = i
         armonias[i] = (arm or "").lower()
 
-    info: list[dict] = []
+    info: List[Dict] = []
     for nombre, _, _ in asignaciones:
         root_pc, suf = parsear_nombre_acorde(nombre)
         ints = INTERVALOS_TRADICIONALES[suf]
@@ -523,10 +523,10 @@ def generar_notas_mixtas(
             }
         )
 
-    contadores: dict[int, int] = {}
-    offsets: dict[int, int] = {}
-    bajo_anterior: int | None = None
-    arm_anterior: str | None = None
+    contadores: Dict[int, int] = {}
+    offsets: Dict[int, int] = {}
+    bajo_anterior: Optional[int] = None
+    arm_anterior: Optional[str] = None
     resultado: List[pretty_midi.Note] = []
 
     for pos in posiciones:
@@ -705,7 +705,7 @@ def _cortar_notas_superpuestas(notas: List[pretty_midi.Note]) -> List[pretty_mid
     artefacts caused by overlapping identical pitches.
     """
 
-    agrupadas: dict[int, List[pretty_midi.Note]] = {}
+    agrupadas: Dict[int, List[pretty_midi.Note]] = {}
     for n in sorted(notas, key=lambda x: (x.pitch, x.start)):
         lista = agrupadas.setdefault(n.pitch, [])
         if lista and lista[-1].end > n.start:
@@ -723,7 +723,7 @@ def exportar_montuno(
     asignaciones: List[Tuple[str, List[int], str]],
     num_compases: int,
     output_path: Path,
-    armonizacion: str | None = None,
+    armonizacion: Optional[str] = None,
     *,
     inicio_cor: int = 0,
     debug: bool = False,
@@ -872,7 +872,7 @@ def _indice_para_corchea(cor: int) -> int:
 
 def procesar_progresion_en_grupos(
     texto: str,
-    armonizacion_default: str | None = None,
+    armonizacion_default: Optional[str] = None,
     *,
     inicio_cor: int = 0,
 ) -> Tuple[List[Tuple[str, List[int], str]], int]:
@@ -902,7 +902,7 @@ def procesar_progresion_en_grupos(
 
     arm_actual = (armonizacion_default or "").capitalize()
 
-    def procesar_token(token: str) -> tuple[str | None, str | None]:
+    def procesar_token(token: str) -> Tuple[Optional[str], Optional[str]]:
         nonlocal arm_actual
 
         m = re.match(r"^\[[A-Z]+\](.*)$", token)

--- a/GeneradorMontunos/modos.py
+++ b/GeneradorMontunos/modos.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 
 import pretty_midi
+from typing import List, Optional
 
 
 from voicings_tradicional import generar_voicings_enlazados_tradicional
@@ -22,13 +23,13 @@ def montuno_tradicional(
     progresion_texto: str,
     midi_ref: Path,
     output: Path,
-    armonizacion: str | None = None,
+    armonizacion: Optional[str] = None,
     *,
     inicio_cor: int = 0,
     return_pm: bool = False,
     aleatorio: bool = False,
-    armonizaciones_custom: list[str] | None = None,
-) -> pretty_midi.PrettyMIDI | None:
+    armonizaciones_custom: Optional[List[str]] = None,
+) -> Optional[pretty_midi.PrettyMIDI]:
     """Generate a montuno in the traditional style.
 
     ``armonizacion`` especifica la forma de duplicar las notas generadas. Por

--- a/GeneradorMontunos/salsa.py
+++ b/GeneradorMontunos/salsa.py
@@ -124,10 +124,10 @@ def get_bass_pitch(cifrado: str, inversion: str) -> int:
         raise ValueError(f"Inversión desconocida: {inversion}")
 
 
-def seleccionar_inversion(anterior: Optional[int], cifrado: str) -> tuple[str, int]:
+def seleccionar_inversion(anterior: Optional[int], cifrado: str) -> Tuple[str, int]:
     """Selecciona la inversión que genere el salto más corto (<= SALTO_MAX)."""
 
-    mejores: list[tuple[int, str, int]] = []
+    mejores: List[Tuple[int, str, int]] = []
     for inv in INVERSIONS:
         pitch = get_bass_pitch(cifrado, inv)
         pitch = _ajustar_rango_flexible(anterior, pitch)
@@ -242,10 +242,10 @@ def _extraer_grupos_con_nombres(
 
 def _cargar_grupos_por_inversion(
     plantillas: Dict[str, pretty_midi.PrettyMIDI],
-) -> tuple[dict[str, List[List[dict]]], int, float, float]:
+) -> Tuple[Dict[str, List[List[Dict]]], int, float, float]:
     """Devuelve notas agrupadas por corchea para cada inversión."""
 
-    grupos_por_inv: dict[str, List[List[dict]]] = {}
+    grupos_por_inv: Dict[str, List[List[Dict]]] = {}
     total_cor_ref = None
     grid = bpm = None
     for inv, pm in plantillas.items():
@@ -282,7 +282,7 @@ def _indice_para_corchea(cor: int) -> int:
 
 def procesar_progresion_salsa(
     texto: str,
-    armonizacion_default: str | None = None,
+    armonizacion_default: Optional[str] = None,
     *,
     inicio_cor: int = 0,
 ) -> Tuple[List[Tuple[str, List[int], str, Optional[str]]], int]:
@@ -310,7 +310,7 @@ def procesar_progresion_salsa(
     arm_actual = (armonizacion_default or "").capitalize()
     inv_forzado: Optional[str] = None
 
-    def procesar_token(token: str) -> tuple[str | None, str | None]:
+    def procesar_token(token: str) -> Tuple[Optional[str], Optional[str]]:
         """Return ``(chord, inversion)`` parsed from ``token``.
 
         The global ``arm_actual`` is updated if the token contains a
@@ -357,7 +357,7 @@ def procesar_progresion_salsa(
 
     for seg in segmentos:
         tokens = [t for t in seg.split() if t]
-        acordes: list[tuple[str, str, Optional[str]]] = []
+        acordes: List[Tuple[str, str, Optional[str]]] = []
         for tok in tokens:
             nombre, inv_local = procesar_token(tok)
             if nombre is None:
@@ -409,10 +409,10 @@ def montuno_salsa(
     inversion_inicial: str = "root",
     *,
     inicio_cor: int = 0,
-    inversiones_manual: list[str] | None = None,
+    inversiones_manual: Optional[List[str]] = None,
     return_pm: bool = False,
     variante: str = "A",   # <-- NUEVO parámetro
-) -> pretty_midi.PrettyMIDI | None:
+) -> Optional[pretty_midi.PrettyMIDI]:
     """Genera montuno estilo salsa enlazando acordes e inversiones.
 
     ``inversion_inicial`` determina la posición del primer acorde y guía el
@@ -452,7 +452,7 @@ def montuno_salsa(
 
     # Carga los midis de referencia una única vez por inversión y
     # construye las posiciones repetidas para toda la progresión
-    plantillas: dict[str, pretty_midi.PrettyMIDI] = {}
+    plantillas: Dict[str, pretty_midi.PrettyMIDI] = {}
     parts = midi_ref.stem.split("_")
     base = "_".join(parts[:2]) if len(parts) >= 2 else midi_ref.stem
     if len(parts) >= 4:

--- a/GeneradorMontunos/style_utils.py
+++ b/GeneradorMontunos/style_utils.py
@@ -1,12 +1,12 @@
 """Helpers for style parsing and application."""
-from typing import Callable, Tuple
+from typing import Callable, List, Tuple
 
 __all__ = ["parse_styles", "apply_styles"]
 
-def parse_styles(text: str, get_modo: Callable[[], str], get_armon: Callable[[], str]) -> Tuple[list[str], list[str], list[str]]:
+def parse_styles(text: str, get_modo: Callable[[], str], get_armon: Callable[[], str]) -> Tuple[List[str], List[str], List[str]]:
     """Return mode, harmonisation and inversion lists for each chord."""
     segmentos_raw = [s.strip() for s in text.split("|") if s.strip()]
-    segmentos: list[str] = []
+    segmentos: List[str] = []
     for seg in segmentos_raw:
         if seg == "%":
             if not segmentos:

--- a/GeneradorMontunos/ui_config.py
+++ b/GeneradorMontunos/ui_config.py
@@ -1,6 +1,7 @@
 import customtkinter as ctk
 from pathlib import Path
 import json
+from typing import Dict, Optional
 
 CONFIG_FILE = Path.home() / ".cajonea2_prefs.json"
 
@@ -16,7 +17,7 @@ COLORS = {
 }
 
 
-def _load_font_from_file(root, name: str) -> str | None:
+def _load_font_from_file(root, name: str) -> Optional[str]:
     try:
         import tkinter.font as tkfont
         font_path = Path(__file__).with_name(name)
@@ -41,7 +42,7 @@ def get_measure_font(root) -> ctk.CTkFont:
     return ctk.CTkFont(family="Monaco", size=14, weight="bold")
 
 
-def load_preferences() -> dict:
+def load_preferences() -> Dict:
     """Load saved appearance preferences from disk.
 
     Returns a dictionary with font settings if available."""
@@ -56,7 +57,7 @@ def load_preferences() -> dict:
     return {}
 
 
-def save_preferences(fonts: dict | None = None) -> None:
+def save_preferences(fonts: Optional[Dict] = None) -> None:
     """Persist current colors and optional font settings to disk."""
     CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
     data = {'colors': COLORS}

--- a/GeneradorMontunos/utils.py
+++ b/GeneradorMontunos/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Miscellaneous helper functions used across the GUI."""
 
-from typing import Callable, Iterable
+from typing import Callable, Iterable, List, Optional, Tuple
 import re
 import pretty_midi
 
@@ -60,11 +60,11 @@ def calc_default_inversions(
     asignaciones,
     inversion_getter: Callable[[], str],
     get_bass_pitch: Callable[[str, str], int],
-    ajustar_rango_flexible: Callable[[int | None, int], int],
-    seleccionar_inversion: Callable[[int | None, str], tuple[str, int]],
-) -> list[str]:
+    ajustar_rango_flexible: Callable[[Optional[int], int], int],
+    seleccionar_inversion: Callable[[Optional[int], str], Tuple[str, int]],
+) -> List[str]:
     """Return default inversions for ``asignaciones`` using the salsa helpers."""
-    invs: list[str] = []
+    invs: List[str] = []
     voz = None
     for idx, data in enumerate(asignaciones):
         cif = data[0]

--- a/GeneradorMontunos/voicings.py
+++ b/GeneradorMontunos/voicings.py
@@ -113,7 +113,7 @@ def generar_voicings_enlazados_tradicional(progresion: List[str]) -> List[List[i
         intervalos = INTERVALOS_TRADICIONALES[suf][:4]
         notas_base = [root + i for i in intervalos]
 
-        candidatos: list[tuple[int, int, list[int], int]] = []
+        candidatos: List[Tuple[int, int, List[int], int]] = []
         for o in range(1, 5):  # octavas razonables para graves
             acorde = [n + 12 * o for n in notas_base]
             for idx_bajo, n in enumerate(acorde):

--- a/GeneradorMontunos/voicings_tradicional.py
+++ b/GeneradorMontunos/voicings_tradicional.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Utilities for generating piano voicings."""
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 import logging
 
 # ---------------------------------------------------------------------------
@@ -90,7 +90,7 @@ def _ajustar_octava(pitch: int) -> int:
     return pitch
 
 
-def _ajustar_octava_flexible(pitch: int, prev: int | None) -> int:
+def _ajustar_octava_flexible(pitch: int, prev: Optional[int]) -> int:
     """Adjust ``pitch`` preferring the fixed range but allowing a small extension."""
 
     def clamp(p: int, lo: int, hi: int) -> int:


### PR DESCRIPTION
## Summary
- avoid builtin generics so code runs on Python <3.9
- remove union `|` syntax so code runs on Python <3.10

## Testing
- `python -m py_compile GeneradorMontunos/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68852edd5fd88333bbcd93085f9d76dd