### PR TITLE
Fix mode transitions

### DIFF
--- a/GeneradorMontunos/modos.py
+++ b/GeneradorMontunos/modos.py
@@ -4,7 +4,7 @@
 from pathlib import Path
 
 import pretty_midi
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 
 from voicings_tradicional import generar_voicings_enlazados_tradicional
@@ -29,15 +29,24 @@ def montuno_tradicional(
     return_pm: bool = False,
     aleatorio: bool = False,
     armonizaciones_custom: Optional[List[str]] = None,
+    asignaciones_custom: Optional[List[Tuple[str, List[int], str]]] = None,
 ) -> Optional[pretty_midi.PrettyMIDI]:
     """Generate a montuno in the traditional style.
 
     ``armonizacion`` especifica la forma de duplicar las notas generadas. Por
     ahora solo se aplica la opción "Octavas".
     """
-    asignaciones, compases = procesar_progresion_en_grupos(
-        progresion_texto, armonizacion, inicio_cor=inicio_cor
-    )
+    if asignaciones_custom is None:
+        asignaciones, compases = procesar_progresion_en_grupos(
+            progresion_texto, armonizacion, inicio_cor=inicio_cor
+        )
+    else:
+        asignaciones = asignaciones_custom
+        compases = (
+            (max(i for _, idxs, _ in asignaciones for i in idxs) + 7) // 8
+            if asignaciones
+            else 0
+        )
     if armonizaciones_custom is not None:
         for idx, arm in enumerate(armonizaciones_custom):
             if idx < len(asignaciones):

--- a/GeneradorMontunos/salsa.py
+++ b/GeneradorMontunos/salsa.py
@@ -412,6 +412,7 @@ def montuno_salsa(
     inversiones_manual: Optional[List[str]] = None,
     return_pm: bool = False,
     variante: str = "A",   # <-- NUEVO parámetro
+    asignaciones_custom: Optional[List[Tuple[str, List[int], str, Optional[str]]]] = None,
 ) -> Optional[pretty_midi.PrettyMIDI]:
     """Genera montuno estilo salsa enlazando acordes e inversiones.
 
@@ -422,9 +423,17 @@ def montuno_salsa(
     """
     # Procesa la progresión. Cada compás puede contener uno o dos acordes
     print("[DEBUG] Texto que llega a procesar_progresion_salsa (Salsa):", repr(progresion_texto))
-    asignaciones, compases = procesar_progresion_salsa(
-        progresion_texto, inicio_cor=inicio_cor
-    )
+    if asignaciones_custom is None:
+        asignaciones, compases = procesar_progresion_salsa(
+            progresion_texto, inicio_cor=inicio_cor
+        )
+    else:
+        asignaciones = asignaciones_custom
+        compases = (
+            (max(i for _, idxs, _, _ in asignaciones for i in idxs) + 7) // 8
+            if asignaciones
+            else 0
+        )
 
     # --------------------------------------------------------------
     # Selección de la inversión para cada acorde enlazando la voz grave


### PR DESCRIPTION
## Summary
- keep global eighth-note count when mixing modes
- allow passing precomputed assignments to montuno generators
- parse progression once and slice per-style segments

## Testing
- `python -m py_compile modos.py salsa.py main.py`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_688537250e8883338759d3c0bd76f7e0