### PR TITLE
Fix piano roll crash on tuple unpacking

### DIFF
--- a/GeneradorMontunos/midi_utils.py
+++ b/GeneradorMontunos/midi_utils.py
@@ -46,7 +46,8 @@ def aplicar_voicings_a_referencia(
     # Mapeo corchea → índice de voicing
     mapa: Dict[int, int] = {}
     max_idx = -1
-    for i, (_, idxs) in enumerate(asignaciones):
+    for i, data in enumerate(asignaciones):
+        idxs = data[1]
         for ix in idxs:
             mapa[ix] = i
             if ix > max_idx:
@@ -140,7 +141,8 @@ def _arm_por_parejas(
 
     # Map each eighth index to the corresponding voicing/chord
     mapa: Dict[int, int] = {}
-    for i, (_, idxs) in enumerate(asignaciones):
+    for i, data in enumerate(asignaciones):
+        idxs = data[1]
         for ix in idxs:
             mapa[ix] = i
 
@@ -222,12 +224,14 @@ def _arm_decimas_intervalos(
     # seventh.
     # ------------------------------------------------------------------
     mapa: Dict[int, int] = {}
-    for i, (_, idxs) in enumerate(asignaciones):
+    for i, data in enumerate(asignaciones):
+        idxs = data[1]
         for ix in idxs:
             mapa[ix] = i
 
     info: List[Dict] = []
-    for nombre, _ in asignaciones:
+    for data in asignaciones:
+        nombre = data[0]
         root_pc, suf = parsear_nombre_acorde(nombre)
         ints = INTERVALOS_TRADICIONALES[suf]
         is_sixth = suf.endswith("6") and "7" not in suf
@@ -356,12 +360,14 @@ def _arm_treceavas_intervalos(
     """
 
     mapa: Dict[int, int] = {}
-    for i, (_, idxs) in enumerate(asignaciones):
+    for i, data in enumerate(asignaciones):
+        idxs = data[1]
         for ix in idxs:
             mapa[ix] = i
 
     info: List[Dict] = []
-    for nombre, _ in asignaciones:
+    for data in asignaciones:
+        nombre = data[0]
         root_pc, suf = parsear_nombre_acorde(nombre)
         ints = INTERVALOS_TRADICIONALES[suf]
         is_sixth = suf.endswith("6") and "7" not in suf
@@ -502,13 +508,16 @@ def generar_notas_mixtas(
 
     mapa: Dict[int, int] = {}
     armonias: Dict[int, str] = {}
-    for i, (_, idxs, arm) in enumerate(asignaciones):
+    for i, data in enumerate(asignaciones):
+        idxs = data[1]
+        arm = data[2]
         for ix in idxs:
             mapa[ix] = i
         armonias[i] = (arm or "").lower()
 
     info: List[Dict] = []
-    for nombre, _, _ in asignaciones:
+    for data in asignaciones:
+        nombre = data[0]
         root_pc, suf = parsear_nombre_acorde(nombre)
         ints = INTERVALOS_TRADICIONALES[suf]
         is_sixth = suf.endswith("6") and "7" not in suf
@@ -743,11 +752,11 @@ def exportar_montuno(
 
     if debug:
         logger.debug("Asignacion de acordes a corcheas:")
-        for acorde, idxs, arm in asignaciones:
+        for acorde, idxs, arm, *_ in asignaciones:
             logger.debug("  %s (%s): %s", acorde, arm, idxs)
 
     if asignaciones:
-        total_dest_cor = max(i for _, idxs, _ in asignaciones for i in idxs) + 1
+        total_dest_cor = max(i for _, idxs, *_ in asignaciones for i in idxs) + 1
     else:
         total_dest_cor = num_compases * 8
     limite_cor = total_dest_cor

--- a/GeneradorMontunos/midi_utils_tradicional.py
+++ b/GeneradorMontunos/midi_utils_tradicional.py
@@ -39,7 +39,8 @@ def aplicar_voicings_a_referencia(
     # Mapeo corchea → índice de voicing
     mapa: Dict[int, int] = {}
     max_idx = -1
-    for i, (_, idxs) in enumerate(asignaciones):
+    for i, data in enumerate(asignaciones):
+        idxs = data[1]
         for ix in idxs:
             mapa[ix] = i
             if ix > max_idx:
@@ -133,7 +134,8 @@ def _arm_por_parejas(
 
     # Map each eighth index to the corresponding voicing/chord
     mapa: Dict[int, int] = {}
-    for i, (_, idxs) in enumerate(asignaciones):
+    for i, data in enumerate(asignaciones):
+        idxs = data[1]
         for ix in idxs:
             mapa[ix] = i
 
@@ -215,12 +217,14 @@ def _arm_decimas_intervalos(
     # seventh.
     # ------------------------------------------------------------------
     mapa: Dict[int, int] = {}
-    for i, (_, idxs) in enumerate(asignaciones):
+    for i, data in enumerate(asignaciones):
+        idxs = data[1]
         for ix in idxs:
             mapa[ix] = i
 
     info: List[Dict] = []
-    for nombre, _ in asignaciones:
+    for data in asignaciones:
+        nombre = data[0]
         root_pc, suf = parsear_nombre_acorde(nombre)
         ints = INTERVALOS_TRADICIONALES[suf]
         is_sixth = suf.endswith("6") and "7" not in suf
@@ -352,12 +356,14 @@ def _arm_treceavas_intervalos(
     """
 
     mapa: Dict[int, int] = {}
-    for i, (_, idxs) in enumerate(asignaciones):
+    for i, data in enumerate(asignaciones):
+        idxs = data[1]
         for ix in idxs:
             mapa[ix] = i
 
     info: List[Dict] = []
-    for nombre, _ in asignaciones:
+    for data in asignaciones:
+        nombre = data[0]
         root_pc, suf = parsear_nombre_acorde(nombre)
         ints = INTERVALOS_TRADICIONALES[suf]
         is_sixth = suf.endswith("6") and "7" not in suf
@@ -505,13 +511,16 @@ def generar_notas_mixtas(
 
     mapa: Dict[int, int] = {}
     armonias: Dict[int, str] = {}
-    for i, (_, idxs, arm) in enumerate(asignaciones):
+    for i, data in enumerate(asignaciones):
+        idxs = data[1]
+        arm = data[2]
         for ix in idxs:
             mapa[ix] = i
         armonias[i] = (arm or "").lower()
 
     info: List[Dict] = []
-    for nombre, _, _ in asignaciones:
+    for data in asignaciones:
+        nombre = data[0]
         root_pc, suf = parsear_nombre_acorde(nombre)
         ints = INTERVALOS_TRADICIONALES[suf]
         is_sixth = suf.endswith("6") and "7" not in suf
@@ -738,11 +747,11 @@ def exportar_montuno(
 
     if debug:
         logger.debug("Asignacion de acordes a corcheas:")
-        for acorde, idxs, arm in asignaciones:
+        for acorde, idxs, arm, *_ in asignaciones:
             logger.debug("  %s (%s): %s", acorde, arm, idxs)
 
     if asignaciones:
-        total_dest_cor = max(i for _, idxs, _ in asignaciones for i in idxs) + 1
+        total_dest_cor = max(i for _, idxs, *_ in asignaciones for i in idxs) + 1
     else:
         total_dest_cor = num_compases * 8
     limite_cor = total_dest_cor

--- a/GeneradorMontunos/modos.py
+++ b/GeneradorMontunos/modos.py
@@ -43,16 +43,16 @@ def montuno_tradicional(
     else:
         asignaciones = asignaciones_custom
         compases = (
-            (max(i for _, idxs, _ in asignaciones for i in idxs) + 7) // 8
+            (max(i for _, idxs, *_ in asignaciones for i in idxs) + 7) // 8
             if asignaciones
             else 0
         )
     if armonizaciones_custom is not None:
         for idx, arm in enumerate(armonizaciones_custom):
             if idx < len(asignaciones):
-                nombre, idxs, _ = asignaciones[idx]
+                nombre, idxs = asignaciones[idx][:2]
                 asignaciones[idx] = (nombre, idxs, arm)
-    acordes = [a for a, _, _ in asignaciones]
+    acordes = [data[0] for data in asignaciones]
     voicings = generar_voicings_enlazados_tradicional(acordes)
     return exportar_montuno(
         midi_ref,


### PR DESCRIPTION
## Summary
- avoid unpacking tuples with forced inversion in MIDI utils
- handle extra tuple elements in traditional MIDI functions
- adapt mode utilities to new tuple structure

## Testing
- `python -m py_compile GeneradorMontunos/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68853e74aca0833380473f47cbde79df