### PR TITLE
Fix dummy note logic

### DIFF
--- a/GeneradorMontunos/midi_utils.py
+++ b/GeneradorMontunos/midi_utils.py
@@ -805,7 +805,12 @@ def exportar_montuno(
 
     if limite > 0:
         has_start = any(n.start <= 0 < n.end and n.pitch > 0 for n in nuevas_notas)
-        has_end = any(n.start < limite and abs(n.end - limite) < 1e-6 and n.pitch > 0 for n in nuevas_notas)
+        has_end = any(
+            n.pitch > 0
+            and n.start < limite
+            and n.end > limite - grid
+            for n in nuevas_notas
+        )
         if not has_start:
             nuevas_notas.append(
                 pretty_midi.Note(

--- a/GeneradorMontunos/midi_utils_tradicional.py
+++ b/GeneradorMontunos/midi_utils_tradicional.py
@@ -799,7 +799,12 @@ def exportar_montuno(
 
     if limite > 0:
         has_start = any(n.start <= 0 < n.end and n.pitch > 0 for n in nuevas_notas)
-        has_end = any(n.start < limite and abs(n.end - limite) < 1e-6 and n.pitch > 0 for n in nuevas_notas)
+        has_end = any(
+            n.pitch > 0
+            and n.start < limite
+            and n.end > limite - grid
+            for n in nuevas_notas
+        )
         if not has_start:
             nuevas_notas.append(
                 pretty_midi.Note(

--- a/GeneradorMontunos/salsa.py
+++ b/GeneradorMontunos/salsa.py
@@ -528,14 +528,28 @@ def montuno_salsa(
     notas_finales = _cortar_notas_superpuestas(notas_finales)
     notas_finales = _recortar_notas_a_limite(notas_finales, limite)
     if limite > 0:
-        notas_finales.append(
-            pretty_midi.Note(
-                velocity=1,
-                pitch=0,
-                start=max(0.0, limite - grid),
-                end=limite,
-            )
+        has_start = any(n.start <= 0 < n.end and n.pitch > 0 for n in notas_finales)
+        has_end = any(
+            n.pitch > 0 and n.start < limite and n.end > limite - grid for n in notas_finales
         )
+        if not has_start:
+            notas_finales.append(
+                pretty_midi.Note(
+                    velocity=1,
+                    pitch=0,
+                    start=0.0,
+                    end=min(grid, limite),
+                )
+            )
+        if not has_end:
+            notas_finales.append(
+                pretty_midi.Note(
+                    velocity=1,
+                    pitch=0,
+                    start=max(0.0, limite - grid),
+                    end=limite,
+                )
+            )
 
     pm_out = pretty_midi.PrettyMIDI()
     inst = pretty_midi.Instrument(


### PR DESCRIPTION
## Summary
- generate dummy notes only when the first or last eighth is silent
- skip dummy notes in preview generation
- add conditional dummy notes when exporting MIDI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68855ce202848333ad81e93afb5679cd