### PR TITLE
Fix unexpected keyword argument in extended harmony

### DIFF
--- a/GeneradorMontunos/main.py
+++ b/GeneradorMontunos/main.py
@@ -475,8 +475,9 @@ def generar(
                     armon_seg = [armonias_custom[i] for i in idxs_seg]
                 else:
                     armon_seg = [chord_armos[i] for i in idxs_seg]
-                kwargs["armonizaciones_custom"] = armon_seg
-                kwargs["aleatorio"] = True
+                if modo_seg == "Tradicional":
+                    kwargs["armonizaciones_custom"] = armon_seg
+                    kwargs["aleatorio"] = True
             try:
                 funcion(
                     "",


### PR DESCRIPTION
## Summary
- avoid passing unsupported arguments to `montuno_armonia_extendida`

## Testing
- `python -m py_compile GeneradorMontunos/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68878e6756688333b2f9eb823e658a57