### PR TITLE
Improve extended harmony mode

### DIFF
--- a/GeneradorMontunos/main.py
+++ b/GeneradorMontunos/main.py
@@ -1363,7 +1363,14 @@ def main():
                     _push_state()
                     nueva_arm = arm_rev[choice]
                     if chord_styles[i] == "Tradicional":
-                        chord_armos[i] = nueva_arm
+                        n = len(chord_armos)
+                        next_change = n
+                        for j in range(i + 1, n):
+                            if chord_armos[j] != chord_armos[i]:
+                                next_change = j
+                                break
+                        for j in range(i, next_change):
+                            chord_armos[j] = nueva_arm
                     actualizar_visualizacion()
 
                 # Arm menus are dynamic; ensure they are registered as well


### PR DESCRIPTION
## Summary
- enable autocomplete for extended harmony chords
- ensure harmony changes propagate across subsequent chords

## Testing
- `python -m py_compile autocomplete.py main.py`
- `python -m py_compile armonia_extendida.py midi_utils.py midi_common.py voicings.py voicings_tradicional.py modos.py salsa.py style_utils.py utils.py ui_config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887f8538fc08333bd2630684e40b355