### PR TITLE
Enable unlimited inversion shifts

### DIFF
--- a/GeneradorMontunos/midi_utils.py
+++ b/GeneradorMontunos/midi_utils.py
@@ -740,6 +740,7 @@ def exportar_montuno(
     debug: bool = False,
     return_pm: bool = False,
     aleatorio: bool = False,
+    voicing_offsets: Optional[List[int]] = None,
 ) -> Optional[pretty_midi.PrettyMIDI]:
     """Generate a new MIDI file with the given voicings.
 
@@ -793,6 +794,12 @@ def exportar_montuno(
         )
 
     limite = limite_cor * grid
+
+    if voicing_offsets:
+        voicings = [
+            [p + voicing_offsets[i] for p in v]
+            for i, v in enumerate(voicings)
+        ]
 
     nuevas_notas = generar_notas_mixtas(
         posiciones, voicings, asignaciones, grid, notas_base=notas_base, debug=debug

--- a/GeneradorMontunos/midi_utils_tradicional.py
+++ b/GeneradorMontunos/midi_utils_tradicional.py
@@ -734,6 +734,7 @@ def exportar_montuno(
     debug: bool = False,
     return_pm: bool = False,
     aleatorio: bool = False,
+    voicing_offsets: Optional[List[int]] = None,
 ) -> Optional[pretty_midi.PrettyMIDI]:
     """Generate a new MIDI file with the given voicings.
 
@@ -784,6 +785,12 @@ def exportar_montuno(
         )
 
     limite = limite_cor * grid
+
+    if voicing_offsets:
+        voicings = [
+            [p + voicing_offsets[i] for p in v]
+            for i, v in enumerate(voicings)
+        ]
 
     nuevas_notas = generar_notas_mixtas(
         posiciones, voicings, asignaciones, grid, notas_base=notas_base, debug=debug

--- a/GeneradorMontunos/modos.py
+++ b/GeneradorMontunos/modos.py
@@ -31,6 +31,7 @@ def montuno_tradicional(
     aleatorio: bool = False,
     armonizaciones_custom: Optional[List[str]] = None,
     asignaciones_custom: Optional[List[Tuple[str, List[int], str]]] = None,
+    voicing_offsets: Optional[List[int]] = None,
 ) -> Optional[pretty_midi.PrettyMIDI]:
     """Generate a montuno in the traditional style.
 
@@ -65,6 +66,7 @@ def montuno_tradicional(
         inicio_cor=inicio_cor,
         return_pm=return_pm,
         aleatorio=aleatorio,
+        voicing_offsets=voicing_offsets,
     )
 
 


### PR DESCRIPTION
## Summary
- store inversion positions as integers to allow octave wrapping
- apply octave offsets when shifting inversions
- support custom offsets in salsa and extended-harmony modes
- propagate offsets through traditional and extended exporters

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6887fe2c03c88333942a7d94e78def52