### PR TITLE
Ensure Ext. mode persistence

### DIFF
--- a/GeneradorMontunos/main.py
+++ b/GeneradorMontunos/main.py
@@ -592,7 +592,7 @@ def main():
     ctk.set_appearance_mode("dark")
     root.title("Generador de Montunos")
 
-    fonts_cfg = load_preferences()
+    fonts_cfg, prefs = load_preferences()
     root.configure(fg_color=COLORS['bg'])
 
     # Load button icons and store references on the root to avoid garbage
@@ -1725,7 +1725,8 @@ def main():
                         'family': measure_font.cget('family'),
                         'size': measure_font.cget('size'),
                     },
-                }
+                },
+                prefs
             )
             win.destroy()
 
@@ -1764,15 +1765,21 @@ def main():
         actualizar_visualizacion()
         _update_text_from_selections()
 
-    # Default mode combobox kept hidden for internal use
-    modo_var = StringVar(value=MODOS_LABELS["Tradicional"])
+    # Default mode combobox kept hidden for internal use. Persist last selection
+    modo_var = StringVar(value=prefs.get('modo', MODOS_LABELS["Tradicional"]))
+
+    def _on_modo_change(*_):
+        _push_state()
+        prefs['modo'] = modo_var.get()
+        actualizar_armonizacion()
+
     modo_combo = ComboBox(
         root,
         variable=modo_var,
         values=list(MODOS_LABELS.values()),
-        command=lambda *_: (_push_state(), actualizar_armonizacion()),
+        command=_on_modo_change,
     )
-    modo_var.trace_add("write", lambda *a: (_push_state(), actualizar_armonizacion()))
+    modo_var.trace_add("write", _on_modo_change)
 
     armon_var = StringVar(value=ARMONIZACION_LABELS[ARMONIZACIONES[0]])
     armon_combo = ComboBox(
@@ -1978,7 +1985,8 @@ def main():
                     'family': measure_font.cget('family'),
                     'size': measure_font.cget('size'),
                 },
-            }
+            },
+            prefs
         )
         if MIDI_PORT is not None:
             try:

--- a/GeneradorMontunos/ui_config.py
+++ b/GeneradorMontunos/ui_config.py
@@ -1,7 +1,7 @@
 import customtkinter as ctk
 from pathlib import Path
 import json
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple, Any
 
 CONFIG_FILE = Path.home() / ".cajonea2_prefs.json"
 
@@ -15,6 +15,8 @@ COLORS = {
     'note_selected': '#ff9800',
     'measure': '#cccccc',
 }
+
+PREFERENCES: Dict[str, Any] = {}
 
 
 def _load_font_from_file(root, name: str) -> Optional[str]:
@@ -42,26 +44,30 @@ def get_measure_font(root) -> ctk.CTkFont:
     return ctk.CTkFont(family="Monaco", size=14, weight="bold")
 
 
-def load_preferences() -> Dict:
+def load_preferences() -> Tuple[Dict, Dict]:
     """Load saved appearance preferences from disk.
 
-    Returns a dictionary with font settings if available."""
+    Returns a tuple ``(fonts, prefs)`` with any stored font settings and
+    miscellaneous preferences."""
     if CONFIG_FILE.exists():
         try:
             with CONFIG_FILE.open() as fh:
                 data = json.load(fh)
             COLORS.update(data.get('colors', {}))
-            return data.get('fonts', {})
+            PREFERENCES.update(data.get('prefs', {}))
+            return data.get('fonts', {}), PREFERENCES
         except Exception:
-            return {}
-    return {}
+            return {}, {}
+    return {}, {}
 
 
-def save_preferences(fonts: Optional[Dict] = None) -> None:
-    """Persist current colors and optional font settings to disk."""
+def save_preferences(fonts: Optional[Dict] = None, prefs: Optional[Dict] = None) -> None:
+    """Persist current colors, fonts and extra preferences to disk."""
     CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
     data = {'colors': COLORS}
     if fonts:
         data['fonts'] = fonts
+    if prefs is not None:
+        data['prefs'] = prefs
     with CONFIG_FILE.open('w') as fh:
         json.dump(data, fh, indent=2)


### PR DESCRIPTION
## Summary
- persist UI state in `ui_config`
- load saved mode preference on startup
- store mode selection when changed

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688804bcd44c833384e114ae57182731