### PR TITLE
Fix voicing_offsets argument

### DIFF
--- a/GeneradorMontunos/armonia_extendida.py
+++ b/GeneradorMontunos/armonia_extendida.py
@@ -386,6 +386,7 @@ def montuno_armonia_extendida(
     return_pm: bool = False,
     variante: str = "A",
     asignaciones_custom: list[tuple[str, list[int], str | None]] | None = None,
+    voicing_offsets: list[int] | None = None,
 ) -> pretty_midi.PrettyMIDI | None:
     """Genera montuno usando las reglas de armonía extendida."""
 
@@ -445,6 +446,9 @@ def montuno_armonia_extendida(
         voicings.append(get_midi_numbers(root, intervalos, pattern))
         offs.append(offsets[idx_i] * 12)
         asign_simple.append((nombre, idxs, ""))
+
+    if voicing_offsets is not None:
+        offs = voicing_offsets
 
     return midi_utils.exportar_montuno(
         midi_ref,


### PR DESCRIPTION
## Summary
- allow `montuno_armonia_extendida` to receive `voicing_offsets`

## Testing
- `python -m py_compile GeneradorMontunos/*.py`
- `python - <<'PY'
from pathlib import Path
from GeneradorMontunos.armonia_extendida import montuno_armonia_extendida
try:
    pm = montuno_armonia_extendida("C D", Path('GeneradorMontunos/reference_midi_loops/salsa_2-3_root.mid'), Path('test.mid'), return_pm=True)
    print('returned', isinstance(pm, object))
except ModuleNotFoundError as e:
    print(e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_688809dd7f308333af685c048d7338ee