### PR TITLE
Fix highlighting refresh and ensure piano roll updates

### DIFF
--- a/GeneradorMontunos/autocomplete.py
+++ b/GeneradorMontunos/autocomplete.py
@@ -254,6 +254,11 @@ class ChordAutocomplete(ctk.CTkTextbox):
             frag = self._current_word()
             self.delete(f"insert-{len(frag)}c", "insert")
             self.insert("insert", choice)
+            # mark the text as modified so external handlers refresh the view
+            try:
+                self.edit_modified(True)
+            except Exception:
+                pass
         self._hide_popup()
         self.focus_set()
         self._highlight()

--- a/GeneradorMontunos/main.py
+++ b/GeneradorMontunos/main.py
@@ -760,6 +760,11 @@ def main():
 
 
         texto.text.edit_modified(False)
+        # Reapply syntax highlighting so mode changes update chord colours
+        try:
+            texto.text._highlight()
+        except Exception:
+            pass
 
 
         def _clear():


### PR DESCRIPTION
## Summary
- trigger re-highlighting after updating selections so mode changes recolor chords
- mark text as modified when picking autocomplete suggestions

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6888179c4884833396ec52272a402736