### PR TITLE
Fix extended harmony suffix handling and inversion UI

### DIFF
--- a/GeneradorMontunos/main.py
+++ b/GeneradorMontunos/main.py
@@ -977,6 +977,7 @@ def main():
             current_inversions[i] = inv + delta
         if current_inversions:
             inversion_var.set(INV_ORDER[current_inversions[0] % len(INV_ORDER)])
+            actualizar_midi()
         _update_text_from_selections()
         actualizar_visualizacion()
 
@@ -1342,6 +1343,9 @@ def main():
                 cur = current_inversions[i]
                 current_inversions[i] = cur + delta
                 var_inv.set(label_map[INV_ORDER[current_inversions[i] % len(INV_ORDER)]])
+                if i == 0:
+                    inversion_var.set(INV_ORDER[current_inversions[0] % len(INV_ORDER)])
+                    actualizar_midi()
                 _update_text_from_selections()
                 actualizar_visualizacion()
 


### PR DESCRIPTION
## Summary
- allow `get_midi_numbers` helpers to accept MIDI pitch classes
- parse extended harmony chords returning integer pitch class
- use extended bass/inversion utilities when generating extended mode
- ensure inversion buttons refresh reference MIDI and piano roll

## Testing
- `python -m py_compile armonia_extendida.py main.py`
- `python - <<'PY'
from pathlib import Path
import armonia_extendida
pm = armonia_extendida.montuno_armonia_extendida('C∆ | Dm7 | G7 | C∆', Path('reference_midi_loops/salsa_2-3_root_2chords.mid'), Path('out.mid'), return_pm=True)
print('generated', len(pm.instruments[0].notes))
PY
`
- `python - <<'PY'
from pathlib import Path
import armonia_extendida
pm = armonia_extendida.montuno_armonia_extendida('C∆13(#11) | F#m7(b5)', Path('reference_midi_loops/salsa_2-3_root_2chords.mid'), Path('tmp.mid'), return_pm=True)
print(len(pm.instruments[0].notes))
PY
`

------
https://chatgpt.com/codex/tasks/task_e_688846f9db588333a11931f1187846be