### PR TITLE
Ensure sequential harmony pattern and correct inversion cycling

### DIFF
--- a/GeneradorMontunos/main.py
+++ b/GeneradorMontunos/main.py
@@ -1341,10 +1341,11 @@ def main():
             def _shift_inv(delta: int, i: int = idx) -> None:
                 _push_state()
                 cur = current_inversions[i]
-                current_inversions[i] = cur + delta
-                var_inv.set(label_map[INV_ORDER[current_inversions[i] % len(INV_ORDER)]])
+                new_val = (cur + delta) % len(INV_ORDER)
+                current_inversions[i] = new_val
+                var_inv.set(label_map[INV_ORDER[new_val]])
                 if i == 0:
-                    inversion_var.set(INV_ORDER[current_inversions[0] % len(INV_ORDER)])
+                    inversion_var.set(INV_ORDER[current_inversions[0]])
                     actualizar_midi()
                 _update_text_from_selections()
                 actualizar_visualizacion()


### PR DESCRIPTION
## Summary
- always traverse the reference sequentially in extended harmony mode
- fix manual inversion controls so they cycle through the three inversions

## Testing
- `python -m py_compile *.py`
- `python - <<'EOF'
import armonia_extendida
from pathlib import Path
pm = armonia_extendida.montuno_armonia_extendida(
    "C | F | G | C",
    Path("reference_midi_loops/salsa_2-3_root_2chords.mid"),
    Path("test.mid"),
    return_pm=True
)
print("notes", len(pm.instruments[0].notes))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68885135d27c833399d43abea8596319