### PR TITLE
Fix IndexError when generating extended montunos

### DIFF
--- a/GeneradorMontunos/midi_utils.py
+++ b/GeneradorMontunos/midi_utils.py
@@ -605,8 +605,14 @@ def generar_notas_mixtas(
             else:  # treceavas
                 notas = [base + 12, agregada - 24]
         else:
-            # Procesamiento estandar del voicing base
+            # Procesamiento estándar del voicing base. ``notas_base`` puede
+            # contener más entradas que las presentes en ``voicing`` cuando
+            # las plantillas incluyen notas adicionales.  Asegura que el
+            # índice calculado no exceda la longitud del voicing para evitar
+            # ``IndexError``.
             orden = notas_base.index(pos["pitch"])
+            if orden >= len(voicing):
+                orden %= len(voicing)
             base_pitch = voicing[orden]
 
             if arm == "octavas":


### PR DESCRIPTION
## Summary
- guard against indexes larger than available voicing notes in `generar_notas_mixtas`

## Testing
- `python3 main.py --debug` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_6888634a6a048333ad93e888590031cd